### PR TITLE
Fix formatting in SKILL.md description

### DIFF
--- a/skills/chat-ui/SKILL.md
+++ b/skills/chat-ui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: chat-ui
-description: "Chat UI building blocks for React/Next.js from ui.inference.sh. Components: container, messages, input, typing indicators, avatars. Capabilities: chat interfaces, message lists, input handling, streaming. Use for: building custom chat UIs, messaging interfaces, AI assistants. Triggers: chat ui, chat component, message list, chat input, shadcn chat,"  react chat, chat interface, messaging ui, conversation ui, chat building blocks
+description: "Chat UI building blocks for React/Next.js from ui.inference.sh. Components: container, messages, input, typing indicators, avatars. Capabilities: chat interfaces, message lists, input handling, streaming. Use for: building custom chat UIs, messaging interfaces, AI assistants. Triggers: chat ui, chat component, message list, chat input, shadcn chat, react chat, chat interface, messaging ui, conversation ui, chat building blocks"
 ---
 
 # Chat UI Components


### PR DESCRIPTION
fix yaml syntax error 

> except yaml.YAMLError as e:
>     print("ERROR:", e)
>     print("\n=== ISSUE IDENTIFIED ===")
>     print("Look at line 3 of the YAML - there's a quote issue:")
>     print('...shadcn chat,"  react chat...')
>     print('              ^^')
>     print("There's a closing quote followed by TWO spaces, then text continues.")
>     print("This breaks the YAML syntax - text after closing quote should be on new line")
>     print("or the quote should be escaped/continued properly.")